### PR TITLE
Rename fragment local variable because of variable shadowing

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
@@ -78,7 +78,7 @@ public class SettingsActivity extends AbstractActivity implements ChooseActivity
     }
 
     private PreferenceFragmentCompat getPreferenceScreen(String key) {
-        PreferenceFragmentCompat fragment = null;
+        PreferenceFragmentCompat LocalFragment = null;
 
         if (key.equals(getString(R.string.settings_defaults_key))) {
             fragment = new DefaultsSettingsFragment();

--- a/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/SettingsActivity.java
@@ -77,7 +77,7 @@ public class SettingsActivity extends AbstractActivity implements ChooseActivity
         return viewBinding.getRoot();
     }
 
-    private PreferenceFragmentCompat getPreferenceScreen(String key) {
+    private PreferenceFragmentCompat getPreferenceScreen(String key){
         PreferenceFragmentCompat LocalFragment = null;
 
         if (key.equals(getString(R.string.settings_defaults_key))) {


### PR DESCRIPTION
updated Rename fragment local variable because of variable shadowing.#10 issue.